### PR TITLE
Changed fields visibility and overwrote toString()

### DIFF
--- a/src/main/java/com/groocraft/couchdb/slacker/DocumentBase.java
+++ b/src/main/java/com/groocraft/couchdb/slacker/DocumentBase.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.StringJoiner;
 
 /**
  * Ancestor of all CouchDB document pojo classes. There is not need to use this class as an ancestor for every pojo class, but it is more easier than define
@@ -36,11 +37,11 @@ public class DocumentBase {
 
     @JsonProperty("_id")
     @JsonInclude(Include.NON_NULL)
-    private String id;
+    protected String id;
 
     @JsonProperty("_rev")
     @JsonInclude(Include.NON_NULL)
-    private String revision;
+    protected String revision;
 
     public DocumentBase() {
     }
@@ -82,5 +83,13 @@ public class DocumentBase {
     @Override
     public int hashCode() {
         return Objects.hash(id, revision);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", DocumentBase.class.getSimpleName() + "[", "]")
+                .add("id='" + id + "'")
+                .add("revision='" + revision + "'")
+                .toString();
     }
 }


### PR DESCRIPTION
As the `DocumentBase` class purpose is to inherit from it, I changed the visibility of the fields from private to protected.

I also missed the toString() method. Best practice to overwrite it, said by Joshua Bloch in Effective Java: https://www.thefinestartist.com/effective-java/10